### PR TITLE
[PAM-1745] Legge til navIdent når stillingen opprettes

### DIFF
--- a/src/ad/adDataReducer.js
+++ b/src/ad/adDataReducer.js
@@ -46,6 +46,7 @@ export const SET_AD_STATUS = 'SET_AD_STATUS';
 export const SET_ADMIN_STATUS = 'SET_ADMIN_STATUS';
 export const SET_AD_TITLE = 'SET_AD_TITLE';
 export const SET_REPORTEE = 'SET_REPORTEE';
+export const SET_NAV_IDENT = 'SET_NAV_IDENT';
 export const SET_UPDATED_BY = 'SET_UPDATED_BY';
 export const SET_PRIVACY = 'SET_PRIVACY';
 export const SET_CONTACT_PERSON = 'SET_CONTACT_PERSON';
@@ -365,6 +366,14 @@ export default function adDataReducer(state = initialState, action) {
                 administration: {
                     ...state.administration,
                     reportee: action.reportee
+                }
+            };
+        case SET_NAV_IDENT:
+            return {
+                ...state,
+                administration: {
+                    ...state.administration,
+                    navIdent: action.navIdent
                 }
             };
         case SET_UPDATED_BY:

--- a/src/ad/adReducer.js
+++ b/src/ad/adReducer.js
@@ -11,6 +11,7 @@ import {
     SET_ADMIN_STATUS,
     SET_COMMENT,
     SET_EXPIRATION_DATE,
+    SET_NAV_IDENT,
     SET_PRIVACY,
     SET_PUBLISHED,
     SET_REPORTEE,
@@ -252,12 +253,14 @@ function* createAd() {
             privacy: PrivacyStatusEnum.INTERNAL_NOT_SHOWN,
             administration: {
                 status: AdminStatusEnum.PENDING,
-                reportee: `${reportee.displayName}[${reportee.userName}]`
+                reportee: reportee.displayName,
+                navIdent: reportee.navIdent
             }
         });
 
         yield put({ type: SET_AD_DATA, data: response });
         yield put({ type: SET_REPORTEE, reportee: reportee.displayName });
+        yield put({ type: SET_NAV_IDENT, navIdent: reportee.navIdent });
         yield put({ type: CREATE_AD_SUCCESS, response });
     } catch (e) {
         if (e instanceof ApiError) {

--- a/src/ad/administration/adminStatus/AdminStatusPreview.js
+++ b/src/ad/administration/adminStatus/AdminStatusPreview.js
@@ -4,25 +4,29 @@ import React from 'react';
 import { connect } from 'react-redux';
 import './AdminStatusPreview.less';
 
-const AdminStatusPreview = ({ reportee }) => (
+const AdminStatusPreview = ({ reportee, navIdent }) => (
     <div className="AdminStatusPreview">
         <Normaltekst>
-            <b>Saksbehandler: </b>
+            <b>Registrert av: </b>
             {reportee || ''}
+            {navIdent ? ` (${navIdent})` : ''}
         </Normaltekst>
     </div>
 );
 
 AdminStatusPreview.defaultProps = {
-    reportee: undefined
+    reportee: undefined,
+    navIdent: undefined
 };
 
 AdminStatusPreview.propTypes = {
-    reportee: PropTypes.string
+    reportee: PropTypes.string,
+    navIdent: PropTypes.string
 };
 
 const mapStateToProps = (state) => ({
-    reportee: state.adData.administration.reportee
+    reportee: state.adData.administration.reportee,
+    navIdent: state.adData.administration.navIdent
 });
 
 export default connect(mapStateToProps)(AdminStatusPreview);


### PR DESCRIPTION
- Lagre NAV-ident sammen med en stilling når den opprettes
- Vise NAV-ident når man går inn på en stilling

Brukerhistorie: https://jira.adeo.no/browse/PAM-1745