### PR TITLE
[PAM-2260] Fiks veiledernavn

### DIFF
--- a/src/topmenu/TopMenu.js
+++ b/src/topmenu/TopMenu.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { VeilederHeaderMeny, VeilederTabId } from 'pam-frontend-header';
-import {FETCH_REPORTEE} from '../reportee/reporteeReducer';
+import { FETCH_REPORTEE } from '../reportee/reporteeReducer';
 import 'pam-frontend-header/dist/style.css';
 
 const HeaderMenu = ({ tabId, displayName, fetchDisplayName, isFetchingDisplayName }) => {


### PR DESCRIPTION
Ref [PAM-2260](https://jira.adeo.no/browse/PAM-2260)

Om man er inne på "Søk etter stillinger" eller en stillingsside og refresher vil veileders navn oppe i høyre hjørne forsvinne.

Har gjort sånn at det alltid sjekkes at man har et gyldig navn å vise når toppmenyen skapes.