### PR TITLE
[PAM-2312] Redirect tilbake til siden bruker var på ved login

### DIFF
--- a/src/login.js
+++ b/src/login.js
@@ -1,8 +1,8 @@
 import { LOGIN_URL } from './fasitProperties';
 
 const whiteList = [
-    'stillinger',
-    'kandidater'
+    '/stillinger',
+    '/kandidater'
 ];
 
 export const redirectToLogin = () => {


### PR DESCRIPTION
Ref [PAM-2312](https://jira.adeo.no/browse/PAM-2312)

Slik det er nå vil bruker alltid bli sendt tilbake til forsiden etter å ha logget inn. Denne fiksen gjør at man kan redirecte til /stillinger og /kandidater. /minestillinger kommer i en senere PR siden det ikke er støtte for redirect til denne i loginservice akkurat nå.