### PR TITLE
[PAM-2771] Remove redundant async backend queries

### DIFF
--- a/src/myAds/myAdsReducer.js
+++ b/src/myAds/myAdsReducer.js
@@ -8,7 +8,7 @@ export const FETCH_MY_ADS_SUCCESS = 'FETCH_MY_ADS_SUCCESS';
 export const FETCH_MY_ADS_FAILURE = 'FETCH_MY_ADS_FAILURE';
 export const CHANGE_MY_ADS_PAGE = 'CHANGE_MY_ADS_PAGE';
 export const RESET_MY_ADS_PAGE = 'RESET_MY_ADS_PAGE';
-export const CHANGE_STATUS_FILTER = 'CHANGE_STATUS_FILTER';
+export const CHANGE_MY_ADS_STATUS_FILTER = 'CHANGE_MY_ADS_STATUS_FILTER';
 
 const INACTIVE = 'INACTIVE';
 const EXPIRED = 'EXPIRED';
@@ -48,7 +48,7 @@ export default function myAdsReducer(state = initialState, action) {
                 error: action.error,
                 isSearching: false
             };
-        case CHANGE_STATUS_FILTER:
+        case CHANGE_MY_ADS_STATUS_FILTER:
             return {
                 ...state,
                 status: action.status,
@@ -125,7 +125,7 @@ function* getMyAds(action) {
 
 export const myAdsSaga = function* saga() {
     yield takeLatest([
-        CHANGE_STATUS_FILTER,
+        CHANGE_MY_ADS_STATUS_FILTER,
         CHANGE_MY_ADS_PAGE,
         FETCH_MY_ADS
     ], getMyAds);

--- a/src/myAds/statusFilter/StatusFilter.js
+++ b/src/myAds/statusFilter/StatusFilter.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Select } from 'nav-frontend-skjema';
-import { FETCH_MY_ADS, CHANGE_STATUS_FILTER } from '../myAdsReducer';
+import { FETCH_MY_ADS, CHANGE_MY_ADS_STATUS_FILTER } from '../myAdsReducer';
 import AdStatusEnum from '../../common/enums/AdStatusEnum';
 import { getAdStatusLabel } from '../../common/enums/getEnumLabels';
 
@@ -15,7 +15,6 @@ class StatusFilter extends React.Component {
         } else {
             this.props.changeStatusFilter(e.target.value, false);
         }
-        this.props.getAds();
     };
 
     // TODO: Dropp className="typo-normal" når Select har SourceSansPro som default font.
@@ -52,8 +51,7 @@ StatusFilter.defaultProps = {
 
 StatusFilter.propTypes = {
     status: PropTypes.string,
-    changeStatusFilter: PropTypes.func.isRequired,
-    getAds: PropTypes.func.isRequired
+    changeStatusFilter: PropTypes.func.isRequired
 };
 
 const mapStateToProps = (state) => ({
@@ -61,8 +59,7 @@ const mapStateToProps = (state) => ({
 });
 
 const mapDispatchToProps = (dispatch) => ({
-    getAds: () => dispatch({ type: FETCH_MY_ADS }),
-    changeStatusFilter: (status, deactivatedByExpiry) => dispatch({ type: CHANGE_STATUS_FILTER, status, deactivatedByExpiry })
+    changeStatusFilter: (status, deactivatedByExpiry) => dispatch({ type: CHANGE_MY_ADS_STATUS_FILTER, status, deactivatedByExpiry })
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(StatusFilter);


### PR DESCRIPTION
* Change redux action type for "myAds" status filter component, so it does not
collide with action type used for the general search page filter.

* Remove unnecessary "getAds" call for my ads when changing status filter.