### PR TITLE
Legg til mulighet til å navigere direkte til redigeringsmodus til stilling via URL

### DIFF
--- a/src/ad/Ad.js
+++ b/src/ad/Ad.js
@@ -53,6 +53,8 @@ class Ad extends React.Component {
     }
 
     onPreviewAdClick = () => {
+        // Fjerner 'redigeringsmodus=true' fra URL
+        this.props.history.replace(this.props.location.pathname);
         this.props.previewAd();
     };
 

--- a/src/ad/Ad.js
+++ b/src/ad/Ad.js
@@ -21,13 +21,17 @@ import LeggTilKandidatAlertStripe from './kandidatModal/LeggTilKandidatAlertStri
 import HasChangesModal from './navigation/HasChangesModal';
 import './Ad.less';
 
+export const REDIGERINGSMODUS_QUERY_PARAM = 'redigeringsmodus';
+
 class Ad extends React.Component {
     componentDidMount() {
         window.scrollTo(0, 0);
         if (this.props.match.params.uuid) {
             this.uuid = this.props.match.params.uuid;
-            const edit = this.props.location.state && this.props.location.state.openInEditMode;
-            this.props.getStilling(this.uuid, edit);
+
+            const queryParams = new URLSearchParams(this.props.location.search);
+            const redigeringsmodus = queryParams.get(REDIGERINGSMODUS_QUERY_PARAM) === 'true';
+            this.props.getStilling(this.uuid, redigeringsmodus);
         } else {
             this.props.createAd();
         }

--- a/src/ad/Ad.js
+++ b/src/ad/Ad.js
@@ -53,9 +53,17 @@ class Ad extends React.Component {
     }
 
     onPreviewAdClick = () => {
-        // Fjerner 'redigeringsmodus=true' fra URL
-        this.props.history.replace(this.props.location.pathname);
+        this.fjernRedigeringsmodusFraUrl();
         this.props.previewAd();
+    };
+
+    fjernRedigeringsmodusFraUrl = () => {
+        const queryParams = new URLSearchParams(this.props.location.search);
+        queryParams.delete(REDIGERINGSMODUS_QUERY_PARAM);
+        this.props.history.replace({
+            pathname: this.props.location.pathname,
+            search: queryParams.toString(),
+        });
     };
 
     render() {

--- a/src/ad/administration/adStatus/AdStatus.js
+++ b/src/ad/administration/adStatus/AdStatus.js
@@ -78,7 +78,6 @@ AdStatus.defaultProps = {
 
 AdStatus.propTypes = {
     adStatus: PropTypes.string.isRequired,
-    isEditingAd: PropTypes.bool.isRequired,
     originalData: PropTypes.shape({
         privacy: PropTypes.string,
         published: PropTypes.string,
@@ -91,7 +90,6 @@ AdStatus.propTypes = {
 const mapStateToProps = (state) => ({
     adStatus: state.adData.status,
     originalData: state.ad.originalData,
-    isEditingAd: state.ad.isEditingAd,
     deactivatedByExpiry: state.adData.deactivatedByExpiry,
     activationOnPublishingDate: state.adData.activationOnPublishingDate,
     isSavingAd: state.ad.isSavingAd,

--- a/src/ad/administration/adStatus/AdStatusEdit.js
+++ b/src/ad/administration/adStatus/AdStatusEdit.js
@@ -84,13 +84,6 @@ class AdStatusEdit extends React.PureComponent {
         });
     };
 
-    OnPreviewAdClick = () => {
-        this.props.previewAd();
-        this.setState({
-            buttonClicked: undefined,
-        });
-    };
-
     onSavePreviewAdClick = () => {
         this.props.saveAd();
         const validation = this.props.validation;

--- a/src/myAds/result/ResultItem.js
+++ b/src/myAds/result/ResultItem.js
@@ -11,6 +11,7 @@ import './Icons.less';
 import './Result.less';
 import { getAdStatusLabel } from '../../common/enums/getEnumLabels';
 import ResultItemDropDown from './ResultItemDropDown';
+import { REDIGERINGSMODUS_QUERY_PARAM } from '../../ad/Ad';
 
 const ResultItem = ({ ad, copiedAds, reportee }) => {
     const [dropDownVisible, setDropDownVisible] = useState(false);
@@ -118,10 +119,7 @@ const ResultItem = ({ ad, copiedAds, reportee }) => {
                     className="Icon__button Inner__button"
                     aria-label="Rediger"
                     title="rediger"
-                    to={{
-                        pathname: `/stilling/${ad.uuid}`,
-                        state: { openInEditMode: true },
-                    }}
+                    to={`/stilling/${ad.uuid}?${REDIGERINGSMODUS_QUERY_PARAM}=true`}
                 >
                     <i className="Edit__icon" />
                 </Link>


### PR DESCRIPTION
Iterasjon 2 av: https://trello.com/c/DgqrgGBT/88-bug-i-kandidatlister-det-skal-ikke-v%C3%A6re-mulig-%C3%A5-f%C3%A5-opp-editeringsmodalen-hvor-man-angir-arbeidsgiver-for-kandidatlister-med-stil

Må legge til 'redigeringsmodus=true' i lenken fra rekrutteringsbistand-kandidat.
