### PR TITLE
Fjern velging av valg i Typeahead med tabbing

### DIFF
--- a/src/common/typeahead/Typeahead.js
+++ b/src/common/typeahead/Typeahead.js
@@ -54,9 +54,9 @@ export default class Typeahead extends React.Component {
 
         switch (e.keyCode) {
             case 9: // Tab
-                if (hasSelectedSuggestion && this.state.shouldShowSuggestions) {
-                    this.setValue(this.props.suggestions[activeSuggestionIndex]);
-                }
+                this.setState({
+                    shouldShowSuggestions: false,
+                });
                 break;
             case 13: // Enter
                 if (hasSelectedSuggestion && this.state.shouldShowSuggestions) {


### PR DESCRIPTION
Fikser denne feilen som oppstår hvis du 
https://sentry.gc.nav.no/nav/rekrutteringsbistand-stilling/issues/17256/?referrer=slack

Det er mulig å velge aktive valg fra Typeahead-komponenten ved å trykke på tab. Men denne switch-casen tar ikke høyde for at komponenten kan ta inn en liste med `optionalSuggestions`. Hvis du velger et element under `optionalSuggestions`-kategorien vil `activeSuggestionIndex` > `suggestions.length`. Da får vi `undefined` som sendes opp til moderkomponentens `onChange`, som ikke tar høyde for at verdien kan være `undefined`.

Det gir uansett ikke mening at Tab skal velge det aktive valget. Fjerner derfor denne logikken, og nå vil tab bare lukke valget og fokusere på neste element.
![image](https://user-images.githubusercontent.com/8887917/101782803-c1587680-3af9-11eb-813e-f871927b37ba.png)
